### PR TITLE
Fallback to 0 for `x` and `y` attributes in `convertRect`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-flatten",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Turns SVG shapes (polygon, polyline, rect, g) into SVG paths. It can merge groups and apply transforms.",
   "main": "src/lib.js",
   "dependencies": {

--- a/src/pathify.js
+++ b/src/pathify.js
@@ -98,8 +98,8 @@ function convertPolyline(dom) {
 }
 
 function convertRect(dom) {
-    var x = parseFloat(dom.attr.x);
-    var y = parseFloat(dom.attr.y);
+    var x = parseFloat(dom.attr.x || 0);
+    var y = parseFloat(dom.attr.y || 0);
     var width = parseFloat(dom.attr.width);
     var height = parseFloat(dom.attr.height);
 


### PR DESCRIPTION
Prevents x and y resulting in `NaN` when no value is present in the attributes.